### PR TITLE
fix compile errors with mingw/gcc

### DIFF
--- a/include/teamspeak/public_definitions.h
+++ b/include/teamspeak/public_definitions.h
@@ -20,6 +20,10 @@
 //minimum amount of seconds before a clientID that was in use can be assigned to a new client
 #define TS3_MIN_SECONDS_CLIENTID_REUSE 300
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#include <_mingw.h>
+#endif
+
 #if defined(WIN32) || defined(__WIN32__) || defined(_WIN32)
 	typedef unsigned __int16 anyID;
 	typedef unsigned __int64 uint64;


### PR DESCRIPTION
The types `__int16` and `__int64` do not exist within gcc, so you must include the `_mingw.h` header file to include macros for the integers if you're on windows.