### PR TITLE
chore(plugin.c): increase api version to 26

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -30,7 +30,7 @@ static struct TS3Functions ts3Functions;
 #define _strcpy(dest, destSize, src) { strncpy(dest, src, destSize-1); (dest)[destSize-1] = '\0'; }
 #endif
 
-#define PLUGIN_API_VERSION 23
+#define PLUGIN_API_VERSION 26
 
 #define PATH_BUFSIZE 512
 #define COMMAND_BUFSIZE 128


### PR DESCRIPTION
To make this plugin template compatible with ts3 client versions >3.6.0, the plugin API version has to be increased to 26.